### PR TITLE
Allow GraXpert commandline to run all extraction methods based on a preferences file

### DIFF
--- a/graxpert/main.py
+++ b/graxpert/main.py
@@ -177,6 +177,7 @@ def main():
         )
         parser.add_argument("-correction", "--correction", nargs="?", required=False, default="Subtraction", choices=["Subtraction", "Division"], type=str, help="Subtraction or Division")
         parser.add_argument("-smoothing", "--smoothing", nargs="?", required=False, default=0.0, type=float, help="Strength of smoothing between 0 and 1")
+        parser.add_argument("-preferencesfile", "--preferencesfile", nargs="?", required=False, default="", type=str, help="Allows GraXpert commandline to run all extraction methods based on a preferences file that contains background grid points")
         parser.add_argument("-output", "--output", nargs="?", required=False, type=str, help="Filename of the processed image")
         parser.add_argument("-bg", "--bg", required=False, action="store_true", help="Also save the background model")
         parser.add_argument("-cli", "--cli", required=False, action="store_true", help="Has to be added when using the command line integration of GraXpert")


### PR DESCRIPTION
- Added new command line parameters
- Moved check for newer version to end of initialization to avoid issues with the initial main window size on macOS
- Allows GraXpert commandline to run all extraction methods based on a preferences file that contains background grid points
