### PR TITLE
Create requirements-metal-macos.txt

### DIFF
--- a/requirements-metal-macos.txt
+++ b/requirements-metal-macos.txt
@@ -1,0 +1,14 @@
+appdirs
+astropy
+customtkinter
+minio
+ml_dtypes
+numpy<=1.24.3,>=1.22
+Pillow
+pykrige
+requests
+scikit-image == 0.21.0
+scipy
+tensorflow == 2.13.1
+tensorflow-metal == v1.0.0
+xisf


### PR DESCRIPTION
Add a requirements file to include tensorflow-metal for the macos versions, enabling hardware acceleration on mac os