### PR TITLE
feat: add OpenVINO runtime support for Intel Arc GPUs

### DIFF
--- a/graxpert/ai_model_handling.py
+++ b/graxpert/ai_model_handling.py
@@ -174,6 +174,12 @@ def get_execution_providers_ordered(gpu_acceleration=True):
 
     if gpu_acceleration:
         supported_providers = [
+            (
+                "OpenVINOExecutionProvider",
+                {
+                    "device_type": "GPU",
+                },
+            ),
             "DmlExecutionProvider",
             (
                 "CoreMLExecutionProvider",


### PR DESCRIPTION
It just takes a few lines in ai_model_handling.py to add the OpenVINO provider and the right flag to force GPU execution. This allows users with an Intel Arc GPU to benefit from the huge speedup in denoising/deconvolution when running on GPU.