### PR TITLE
Add support for devcontainers and make Github CI work again

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,10 @@ ARG USERNAME=vscode
 USER root
 
 RUN apt update
-RUN apt install -y libgl1-mesa-glx
+RUN apt install -y libgl1-mesa-glx 
+
+# extra packages needed for debugging native crashes in python
+# RUN apt install -y python3-venv python3-dbg python3-tk-dbg
 
 # Default user for devcontainer
 USER vscode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# Run inside a recent debian based image with python3, pip3, git and sudo installed
+FROM mcr.microsoft.com/devcontainers/python:3-bookworm
+
+# We use 'user' as the name to match what the zhephyr-build image already created
+ARG USERNAME=vscode
+
+## Setup a user with sudo support
+USER root
+
+RUN apt update
+RUN apt install -y libgl1-mesa-glx
+
+# Default user for devcontainer
+USER vscode
+

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 # Run inside a recent debian based image with python3, pip3, git and sudo installed
-FROM mcr.microsoft.com/devcontainers/python:3-bookworm
+# We are careful to use the python 3.12 version, because the rocm precompiled python native code for onxruntime is only available for a few versions
+FROM python:3.12-slim-bookworm
 
 # We use 'user' as the name to match what the zhephyr-build image already created
 ARG USERNAME=vscode
@@ -8,11 +9,18 @@ ARG USERNAME=vscode
 USER root
 
 RUN apt update
-RUN apt install -y libgl1-mesa-glx 
+RUN apt install -y libgl1-mesa-glx wget sudo
+
+# Create a non-root user if one doesn't exist, and give it sudo rights
+RUN if ! id -u ${USERNAME} > /dev/null 2>&1; then \
+        groupadd --gid 1000 ${USERNAME} && \
+        useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash ${USERNAME} && \
+        echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}-nopasswd; \
+    fi
 
 # extra packages needed for debugging native crashes in python
 # RUN apt install -y python3-venv python3-dbg python3-tk-dbg
 
 # Default user for devcontainer
-USER vscode
+USER ${USERNAME}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,17 +15,22 @@
 
 		"--name=graxpert-devcontainer", // For easier management
 
-		"--user=1000:1000",
-		"--userns=keep-id:uid=1000,gid=1000",
+		"--user=1000:1000"
 
-		"--ulimit=core=-1:-1" // Allow core dumps
+		// Not allowed in github CI devcontainers
+		// "--userns=keep-id:uid=1000,gid=1000",
+
+		// Not needed for now
+		// "--ulimit=core=-1:-1" // Allow core dumps
 	],
 	"mounts": [
-		// Needed for x11 forwarding
-    	"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
-		"source=/run/user/1000,target=/run/user/1000,type=bind",
+		// Needed for x11 forwarding, but throws: invalid mount config for type "bind": bind source path does not exist: /run/user/1000
+		// on github CI.  So disable for now.
+    	//"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
+		//"source=/run/user/1000,target=/run/user/1000,type=bind",
 
-		"source=${localEnv:HOME}/Pictures/telescope,target=/images,type=bind,consistency=cached"
+		// It is handy to have some test images available in the container
+		// "source=${localEnv:HOME}/Pictures/telescope,target=/images,type=bind,consistency=cached",
 
 	],
 	"containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,13 +9,16 @@
 	},
 	"postCreateCommand": "bash .devcontainer/post-create.sh",
 	"runArgs": [
-		//"--privileged", // Allow full hw access from host
+		"--privileged", // Allow full hw access from host, also allows writing core dump files
 		//"--network=host", // Use host network rather than our bridged container network
+		"--ipc=host", // Needed to make python SharedMemory work
 
 		"--name=graxpert-devcontainer", // For easier management
 
 		"--user=1000:1000",
-		"--userns=keep-id:uid=1000,gid=1000"
+		"--userns=keep-id:uid=1000,gid=1000",
+
+		"--ulimit=core=-1:-1" // Allow core dumps
 	],
 	"mounts": [
 		// Needed for x11 forwarding
@@ -28,7 +31,9 @@
 	"containerEnv": {
 		// Needed for X11 forwarding
 		"DISPLAY": "${localEnv:DISPLAY}",
-		"XAUTHORITY": "${localEnv:XAUTHORITY}"
+		"XAUTHORITY": "${localEnv:XAUTHORITY}",
+
+		"PYTHONDEVMODE": "1" // Enable Python dev mode for better debug output
 	},
 	"remoteUser": "vscode",
 	"customizations": {
@@ -51,8 +56,10 @@
 			"extensions": [
 				"ms-azuretools.vscode-docker",
 				"ms-python.python",
-    			"ms-python.vscode-pylance",
-				"shardulm94.trailing-spaces"
+    			"ms-python.vscode-pylance"
+
+				// For the time being leave this off, the existing codebase has lots of trailing spaces
+				// "shardulm94.trailing-spaces"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+{
+	"name": "graxpert-devcontainer",
+
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"WORKSPACE": "${containerWorkspaceFolder}"
+		}
+	},
+	"postStartCommand": "bash .devcontainer/post-create.sh",
+	"runArgs": [
+		//"--privileged", // Allow full hw access from host
+		//"--network=host", // Use host network rather than our bridged container network
+
+		"--name=graxpert-devcontainer", // For easier management
+
+		"--user=1000:1000",
+		"--userns=keep-id:uid=1000,gid=1000"
+	],
+	"mounts": [
+		// Needed for x11 forwarding
+    	"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
+		"source=/run/user/1000,target=/run/user/1000,type=bind"
+	],
+	"containerEnv": {
+		// Needed for X11 forwarding
+		"DISPLAY": "${localEnv:DISPLAY}",
+		"XAUTHORITY": "${localEnv:XAUTHORITY}"
+	},
+	"remoteUser": "vscode",
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"terminal.integrated.profiles.linux": {
+					"bash": {
+						"path": "bash"
+					}
+				},
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"python": {
+					// "terminal.activateEnvInCurrentTerminal": "true",
+					// "defaultInterpreterPath": ".venv/bin/python"
+				}
+			},
+			"remote.extensionKind": {
+				"ms-azuretools.vscode-docker": ["ui"]
+				},
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"ms-python.python",
+    			"ms-python.vscode-pylance",
+				"shardulm94.trailing-spaces"
+			]
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 			"WORKSPACE": "${containerWorkspaceFolder}"
 		}
 	},
-	"postStartCommand": "bash .devcontainer/post-create.sh",
+	"postCreateCommand": "bash .devcontainer/post-create.sh",
 	"runArgs": [
 		//"--privileged", // Allow full hw access from host
 		//"--network=host", // Use host network rather than our bridged container network
@@ -20,7 +20,10 @@
 	"mounts": [
 		// Needed for x11 forwarding
     	"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
-		"source=/run/user/1000,target=/run/user/1000,type=bind"
+		"source=/run/user/1000,target=/run/user/1000,type=bind",
+
+		"source=${localEnv:HOME}/Pictures/telescope,target=/images,type=bind,consistency=cached"
+
 	],
 	"containerEnv": {
 		// Needed for X11 forwarding

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
+export USER=`whoami`
+
+# the devcontainer mount of vscode/.local/share implicity makes the owner root (which is bad)
+echo "Fixing permissions"
+# Some containers might not have a .local directory at all, don't fail in that case
+mkdir ~/.local | true
+sudo chown -R $USER ~/.local
+
 echo "Installing python requirements"
 pip3 install --user -r requirements.txt

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Installing python requirements"
+pip3 install --user -r requirements.txt

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,7 +54,7 @@ jobs:
   #         retention-days: 5
 
   build-linux-zip:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -168,15 +168,29 @@ jobs:
         run: brew install create-dmg
       - name: create .dmg
         run: |
-          create-dmg \
-          --volname "GraXpert-macos-arm64" \
-          --window-pos 50 50 \
-          --window-size 1920 1080 \
-          --icon-size 100 \
-          --icon "GraXpert.app" 200 190 \
-          --app-drop-link 400 190 \
-          "dist/GraXpert-macos-arm64.dmg" \
-          "dist/GraXpert.app/"
+          # The currently available github macos runners have a bug that cause occasional create-dmg failures
+          # with the message "hdiutil: create failed - Resource busy"
+          # FIXME: Undo this nasty retry loop once the following issue gets figured out:
+          #        https://github.com/actions/runner-images/issues/7522#issuecomment-2534682126
+          max_tries=10
+          i=0
+          until create-dmg \
+            --volname "GraXpert-macos-arm64" \
+            --window-pos 50 50 \
+            --window-size 1920 1080 \
+            --icon-size 100 \
+            --icon "GraXpert.app" 200 190 \
+            --app-drop-link 400 190 \
+            "dist/GraXpert-macos-arm64.dmg" \
+            "dist/GraXpert.app/"
+          do
+              if [ $i -eq $max_tries ]
+              then
+                  echo 'Error: create-dmg did not succeed even after 10 tries.'
+                  exit 1
+              fi
+              ((i++))
+          done
       - name: store artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -228,15 +242,29 @@ jobs:
         run: brew install create-dmg
       - name: create .dmg
         run: |
-          create-dmg \
-          --volname "GraXpert-macos-x86_64" \
-          --window-pos 50 50 \
-          --window-size 1920 1080 \
-          --icon-size 100 \
-          --icon "GraXpert.app" 200 190 \
-          --app-drop-link 400 190 \
-          "dist/GraXpert-macos-x86_64.dmg" \
-          "dist/GraXpert.app/"
+          # The currently available github macos runners have a bug that cause occasional create-dmg failures
+          # with the message "hdiutil: create failed - Resource busy"
+          # FIXME: Undo this nasty retry loop once the following issue gets figured out:
+          #        https://github.com/actions/runner-images/issues/7522#issuecomment-2534682126
+          max_tries=10
+          i=0
+          until create-dmg \
+            --volname "GraXpert-macos-x86_64" \
+            --window-pos 50 50 \
+            --window-size 1920 1080 \
+            --icon-size 100 \
+            --icon "GraXpert.app" 200 190 \
+            --app-drop-link 400 190 \
+            "dist/GraXpert-macos-x86_64.dmg" \
+            "dist/GraXpert.app/"
+          do
+              if [ $i -eq $max_tries ]
+              then
+                  echo 'Error: create-dmg did not succeed even after 10 tries.'
+                  exit 1
+              fi
+              ((i++))
+          done            
       - name: store artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -175,6 +175,7 @@ jobs:
           max_tries=10
           i=0
           until create-dmg \
+            --no-internet-enable \
             --volname "GraXpert-macos-arm64" \
             --window-pos 50 50 \
             --window-size 1920 1080 \
@@ -249,6 +250,7 @@ jobs:
           max_tries=10
           i=0
           until create-dmg \
+            --no-internet-enable \
             --volname "GraXpert-macos-x86_64" \
             --window-pos 50 50 \
             --window-size 1920 1080 \

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,5 +75,15 @@ jobs:
       - name: Run tests
         run: python3 -m pytest --import-mode=append tests/
 
+  test-devcontainer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
 
-
+      - name: Run tests in dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            pip install --user pytest
+            python -m pytest --import-mode=append tests/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,8 @@ jobs:
         uses: actions/checkout@v3
       - name: install dependencies
         run: |
-          pip install -r requirements.txt && \
+          pip install -r requirements.txt
+          pip install onnxruntime-gpu
           pip install pytest
       - name: patch version
         run: |
@@ -42,7 +43,8 @@ jobs:
         uses: actions/checkout@v3
       - name: install dependencies
         run: |
-          pip install -r requirements.txt && `
+          pip install -r requirements.txt
+          pip install onnxruntime-gpu
           pip install pytest
       - name: patch version
         run: ./releng/patch_version.ps1
@@ -52,7 +54,7 @@ jobs:
         run: python -m pytest --import-mode=append tests/
 
   test-macos-x86_64:
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -64,8 +66,8 @@ jobs:
       - name: install dependencies
         run: |
           brew install python-tk && \
-          pip3 install -r requirements.txt
-          pip3 install pytest
+          pip3 install --break-system-packages -r requirements.txt
+          pip3 install --break-system-packages pytest
       - name: patch version
         run: |
           chmod u+x ./releng/patch_version.sh && \

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
       - develop
 
 jobs: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,13 +77,27 @@ jobs:
 
   test-devcontainer:
     runs-on: ubuntu-latest
+    # These permissions are needed to push the devcontainer image to the GitHub Container Registry
+    permissions:
+      contents: read
+      packages: write 
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run tests in dev container
         uses: devcontainers/ci@v0.3
         with:
+          # Use this as a cache to avoid rebuilding the container on every CI run (also devs can use it as a known working prebuilt dev environment for main branch)
+          imageName: ghcr.io/${{ github.repository_owner }}/graxpert-${{ github.ref_name }}-devcontainer
+
           runCmd: |
             pip install --user pytest
             python -m pytest --import-mode=append tests/

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Open your terminal or command prompt and use git to clone the GraXpert repositor
 git clone https://github.com/Steffenhir/GraXpert
 cd GraXpert
 ```
+## Option 1: Manual developer environment setup
 
-## Setting up a Virtual Environment
+### Setup the Virtual Environment
 We recommend using a virtual environment to isolate the project's dependencies. Ensure you have Python>=3.10 installed on your system before proceeding. Here's how to set up a virtual environment with Python:
 Windows:
 ```
@@ -94,7 +95,7 @@ python3 -m venv graxpert-env
 source graxpert-env/bin/activate
 ```
 
-## Install required packages
+### Install required packages
 All the requirements can be found in the requirements.txt file. You can install them with:
 
 Windows and Linux:
@@ -114,8 +115,15 @@ and solves issues with macOS Sonoma. Please use the version matching with your P
 brew install python-tk@3.10
 ```
 
+## Option 2: Automatic setup with devcontainers
+This project includes an (optional) [devcontainer](https://containers.dev/) configuration.  If you are using any editor with built-in devcontainer support (i.e. VScode or jetbrains etc...), you should get prompted to "Reopen in a devcontainer?"
+
+If you choose to use a devcontainer a docker (or podman) based container environment will be created for your development.  This environment appears to be a Debian machine (regardless of your host-OS).  All windowing/file/network operations are forwarded through your host.
+
+This provides a nice 'guaranteed' repeatable build/debug environment for all developers.
+
 ## Running GraXpert
-Once you have set up the virtual environment and installed the required packages, you can start GraXpert:
+Once you have set up the virtual environment (using either of the options above), you can start GraXpert in your shell:
 
 ```
 python -m graxpert.main

--- a/releng/patch_version.sh
+++ b/releng/patch_version.sh
@@ -5,10 +5,10 @@ IFS=' ' read -r version release <<< $tag
 
 if [[ $release != "" && $version != "" ]]; 
 then
-  sed -i'.bak' "s/RELEASE/$release/" ./graxpert/version.py
-  sed -i'.bak' "s/SNAPSHOT/$version/" ./graxpert/version.py
-  sed -i'.bak' "s/RELEASE/$release/" ./GraXpert-macos-x86_64.spec
-  sed -i'.bak' "s/SNAPSHOT/$version/" ./GraXpert-macos-x86_64.spec
+  sed -i'.bak' "s^RELEASE^$release^" ./graxpert/version.py
+  sed -i'.bak' "s^SNAPSHOT^$version^" ./graxpert/version.py
+  sed -i'.bak' "s^RELEASE^$release^" ./GraXpert-macos-x86_64.spec
+  sed -i'.bak' "s^SNAPSHOT^$version^" ./GraXpert-macos-x86_64.spec
 else
   echo "WARNING: Could not retrieve git release tag"
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ requests
 scikit-image
 scipy
 xisf
+onnxruntime
+onnxruntime-gpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ scikit-image
 scipy
 xisf
 onnxruntime
-onnxruntime-gpu


### PR DESCRIPTION
This provides nice 'easy' guaranteed identical/repeatable build environment for developers.  Rough instructions added to README.md.  Tested on a fedora host, but presumably works on windows or OS-X as well (if anyone tries this please let me know how it goes).

