### PR TITLE
Install the python faulthandler code (even for non devs)

### DIFF
--- a/graxpert/main.py
+++ b/graxpert/main.py
@@ -12,6 +12,7 @@ import logging
 import multiprocessing
 import re
 import sys
+import faulthandler
 
 from packaging import version
 
@@ -407,5 +408,6 @@ def main():
 if __name__ == "__main__":
     multiprocessing.freeze_support()
     configure_logging()
+    faulthandler.enable(sys.__stderr__)
     main()
     logging.shutdown()


### PR DESCRIPTION
Graxpert can sometimes crash in native code.  And without the python fault handler debugging such crashes is almost impossible.  Turn on the fault handler so that if a crash occurs for an end-user it is more likely they can send in at least stack traces.

Without this change a native crash log looks like:

```
Bus error (core dumped)
```

With this change a native crash log looks like:
```
vscode ➜ /workspaces/graxpert (main) $ python -X faulthandler -m graxpert.main
2025-07-08 18:39:28,113 MainProcess root INFO     /home/vscode/.config/GraXpert/preferences.json appears to be missing. it will be created after program shutdown
...
2025-07-08 18:39:33,268 MainProcess root WARNING  Could not check for newest version
Fatal Python error: Bus error

Thread 0x00007f81c71e16c0 (most recent call first):
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 395 in _recv
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 430 in _recv_bytes
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 250 in recv
  File "/usr/local/lib/python3.13/multiprocessing/managers.py", line 831 in _callmethod
  File "<string>", line 2 in get
  File "/workspaces/graxpert/graxpert/mp_logging.py", line 82 in logger_thread
  File "/usr/local/lib/python3.13/threading.py", line 992 in run
  File "/usr/local/lib/python3.13/threading.py", line 1041 in _bootstrap_inner
  File "/usr/local/lib/python3.13/threading.py", line 1012 in _bootstrap

Current thread 0x00007f821addbb80 (most recent call first):
  File "/workspaces/graxpert/graxpert/stretch.py", line 74 in stretch_all
  File "/workspaces/graxpert/graxpert/AstroImageRepository.py", line 85 in stretch_all
  File "/workspaces/graxpert/graxpert/application/app.py", line 560 in do_stretch
  File "/workspaces/graxpert/graxpert/application/app.py", line 549 in on_stretch_option_changed
  File "/workspaces/graxpert/graxpert/application/eventbus.py", line 21 in emit
  File "/workspaces/graxpert/graxpert/ui/statusbar.py", line 22 in <lambda>
  File "/usr/local/lib/python3.13/tkinter/__init__.py", line 2068 in __call__
  File "/usr/local/lib/python3.13/tkinter/__init__.py", line 427 in set
  File "/home/vscode/.local/lib/python3.13/site-packages/customtkinter/windows/widgets/ctk_optionmenu.py", line 381 in _dropdown_callback
  File "/home/vscode/.local/lib/python3.13/site-packages/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py", line 106 in _button_callback
  File "/home/vscode/.local/lib/python3.13/site-packages/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py", line 96 in <lambda>
  File "/usr/local/lib/python3.13/tkinter/__init__.py", line 2068 in __call__
  File "/usr/local/lib/python3.13/tkinter/__init__.py", line 1599 in mainloop
  File "/home/vscode/.local/lib/python3.13/site-packages/customtkinter/windows/ctk_tk.py", line 165 in mainloop
  File "/workspaces/graxpert/graxpert/main.py", line 186 in ui_main
  File "/workspaces/graxpert/graxpert/main.py", line 404 in main
  File "/workspaces/graxpert/graxpert/main.py", line 410 in <module>
  File "<frozen runpy>", line 88 in _run_code
  File "<frozen runpy>", line 198 in _run_module_as_main

Extension modules: numpy._core._multiarray_umath, numpy.linalg._umath_linalg, zstandard.backend_c, _cffi_backend, PIL._imaging, charset_normalizer.md, requests.packages.charset_normalizer.md, requests.packages.chardet.md, astropy.io.fits._utils, astropy.io.fits.hdu.compressed._compression, scipy._lib._ccallback_c, scipy.linalg._fblas, scipy.linalg._flapack, _cyutility, scipy._cyutility, scipy.linalg.cython_lapack, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator, scipy.linalg._cythonized_array_utils, scipy.linalg._solve_toeplitz, scipy.linalg._decomp_lu_cython, scipy.linalg._matfuncs_schur_sqrtm, scipy.linalg._matfuncs_expm, scipy.linalg._linalg_pythran, scipy.linalg.cython_blas, scipy.linalg._decomp_update, scipy.sparse._sparsetools, _csparsetools, scipy.sparse._csparsetools, lz4._version, lz4.block._block, astropy.stats._stats, erfa.ufunc, astropy.stats._fast_sigma_clip, scipy.spatial._ckdtree, scipy._lib.messagestream, scipy.spatial._qhull, scipy.spatial._voronoi, scipy.special._ufuncs_cxx, scipy.special._ellip_harm_2, scipy.special._special_ufuncs, scipy.special._gufuncs, scipy.special._ufuncs, scipy.special._specfun, scipy.special._comb, scipy.spatial._hausdorff, scipy.spatial._distance_wrap, scipy.spatial.transform._rotation, scipy.spatial.transform._rigid_transform, scipy.sparse.linalg._dsolve._superlu, scipy.sparse.linalg._eigen.arpack._arpack, scipy.sparse.linalg._propack._spropack, scipy.sparse.linalg._propack._dpropack, scipy.sparse.linalg._propack._cpropack, scipy.sparse.linalg._propack._zpropack, scipy.optimize._group_columns, scipy.optimize._trlib._trlib, scipy.optimize._lbfgsb, _moduleTNC, scipy.optimize._moduleTNC, scipy.optimize._slsqplib, scipy.optimize._minpack, scipy.optimize._lsq.givens_elimination, scipy.optimize._zeros, scipy._lib._uarray._uarray, scipy.linalg._decomp_interpolative, scipy.optimize._bglu_dense, scipy.optimize._lsap, scipy.optimize._direct, scipy.interpolate._fitpack, scipy.interpolate._dfitpack, scipy.interpolate._dierckx, scipy.interpolate._ppoly, scipy.interpolate._interpnd, scipy.interpolate._rbfinterp_pythran, scipy.interpolate._rgi_cython, PIL._imagingmath, PIL._imagingtk (total: 85)
Bus error (core dumped)
```