### PR TITLE
Small visual adjustments for progress popups

### DIFF
--- a/graxpert/ui/loadingframe.py
+++ b/graxpert/ui/loadingframe.py
@@ -42,6 +42,9 @@ class DynamicProgressFrame(CTkFrame):
     def __init__(self, parent, label_lext=_("Progress:"), cancellable=False, **kwargs):
         super().__init__(parent, **kwargs)
 
+        self.inner_frame = CTkFrame(self, fg_color="transparent")
+        self.inner_frame.grid(row=0, column=0, sticky=tk.NSEW, padx=10, pady=(5, 10))
+
         self.text = StringVar(self, value=label_lext)
         self.variable = DoubleVar(self, value=0.0)
         self.cancellable = cancellable
@@ -52,13 +55,14 @@ class DynamicProgressFrame(CTkFrame):
 
     def create_children(self):
         self.label = CTkLabel(
-            self,
+            self.inner_frame,
             textvariable=self.text,
             width=280,
         )
-        self.pb = CTkProgressBar(self, variable=self.variable)
+        self.pb = CTkProgressBar(self.inner_frame, variable=self.variable)
+        self.pb.grid(column=0, row=0, sticky=tk.NSEW, pady=10)
         self.cancel_button = CTkButton(
-            self,
+            self.inner_frame,
             text=_("Cancel"),
             command=lambda: eventbus.emit(AppEvents.CANCEL_PROCESSING),
             fg_color=ThemeManager.theme["Accent.CTkButton"]["fg_color"],
@@ -66,8 +70,8 @@ class DynamicProgressFrame(CTkFrame):
         )
 
     def setup_layout(self):
-        self.columnconfigure(0, weight=1)
-        self.rowconfigure(0, weight=1)
+        self.inner_frame.columnconfigure(0, weight=1)
+        self.inner_frame.rowconfigure(0, weight=1)
 
     def place_children(self):
         self.label.grid(column=0, row=0, sticky=tk.NSEW)


### PR DESCRIPTION
Introduces a paddings for better visual spacing in progress popups.

Before:
![image](https://github.com/user-attachments/assets/af9cdcf4-300d-4246-9ee7-84d9330a3c71)
After:
![telegram-cloud-photo-size-4-6012323838211246959-x](https://github.com/user-attachments/assets/782d6a55-1d7f-4271-8e02-4ae60c03e078)

Tested on 5 popups:
* Denoising
* Deconvolving
* Downloading AI-Model
* Progress:
* Extracting Background

![telegram-cloud-photo-size-4-6012323838211246959-x](https://github.com/user-attachments/assets/0303c849-8c51-4c45-b2e6-c239fa41958b)

![IMAGE 2025-07-08 20:49:45](https://github.com/user-attachments/assets/e254a719-7781-4058-b61a-e07868d31568)

![telegram-cloud-photo-size-4-6012323838211246961-x](https://github.com/user-attachments/assets/e761d491-a591-45fe-bb5b-e46c5aceb101)

![telegram-cloud-photo-size-4-6012323838211246962-x](https://github.com/user-attachments/assets/288b7727-1d6c-4f27-9b49-7bb9f4006eb2)

![telegram-cloud-photo-size-4-6012323838211246963-x](https://github.com/user-attachments/assets/29837383-b4cc-48f4-b91d-daccebbfa629)
