### PR TITLE
Fix app hang on exit if an exception occurs

### DIFF
--- a/graxpert/mp_logging.py
+++ b/graxpert/mp_logging.py
@@ -87,7 +87,7 @@ def logger_thread(queue):
 
 
 def initialize_logging():
-    logging_thread = threading.Thread(target=logger_thread, args=(get_logging_queue(),))
+    logging_thread = threading.Thread(target=logger_thread, args=(get_logging_queue(),), daemon=True)
     logging_thread.start()
     return logging_thread
 


### PR DESCRIPTION
If an exception occurs in any of the threads of the app, the user will see that as an app hang.  The reason it appears to hang (rather than exiting after the fatal uncaught exception occurs) is that the logging subsystem wasn't marking its thread as a daemon thread.

Since there was a remaining !daemon thread still running python doesn't exit.  The correct setting for a background thread like that mp_logging thread is daemon=true.