### PR TITLE
Fix Apple Silicon denoising acceleration

### DIFF
--- a/graxpert/ai_model_handling.py
+++ b/graxpert/ai_model_handling.py
@@ -170,7 +170,21 @@ def validate_local_version(ai_models_dir, local_version):
     return os.path.isfile(os.path.join(ai_models_dir, local_version, "model.onnx"))
 
 
-def get_execution_providers_ordered(gpu_acceleration=True):
+COREML_MODEL_FORMAT_MLPROGRAM = "MLProgram"
+COREML_MODEL_FORMAT_NEURALNETWORK = "NeuralNetwork"
+COREML_MODEL_FORMATS = {
+    COREML_MODEL_FORMAT_MLPROGRAM,
+    COREML_MODEL_FORMAT_NEURALNETWORK,
+}
+
+
+def get_execution_providers_ordered(
+    gpu_acceleration=True,
+    coreml_model_format=COREML_MODEL_FORMAT_MLPROGRAM,
+):
+
+    if coreml_model_format not in COREML_MODEL_FORMATS:
+        raise ValueError(f"Unsupported Core ML model format: {coreml_model_format}")
 
     if gpu_acceleration:
         supported_providers = [
@@ -178,7 +192,9 @@ def get_execution_providers_ordered(gpu_acceleration=True):
             (
                 "CoreMLExecutionProvider",
                 {
-                    "flags": "COREML_FLAG_CREATE_MLPROGRAM",
+                    "ModelFormat": coreml_model_format,
+                    "MLComputeUnits": "ALL",
+                    "RequireStaticInputShapes": "0",
                 },
             ),
             "CUDAExecutionProvider",

--- a/graxpert/denoising.py
+++ b/graxpert/denoising.py
@@ -67,7 +67,20 @@ def denoise(image, ai_path, strength, batch_size=4, window_size=256, stride=128,
     output = copy.deepcopy(image)
 
     providers = get_execution_providers_ordered(ai_gpu_acceleration)
-    session = ort.InferenceSession(ai_path, providers=providers)
+
+    # Core ML cannot compile the denoising MLProgram efficiently while its
+    # batch dimension is dynamic. Fixing the dimension lets Apple Silicon run
+    # the supported graph partitions on Core ML instead of falling back to CPU.
+    coreml_enabled = any(
+        (provider[0] if isinstance(provider, tuple) else provider) == "CoreMLExecutionProvider"
+        for provider in providers
+    )
+    if coreml_enabled:
+        session_options = ort.SessionOptions()
+        session_options.add_free_dimension_override_by_name("batch_size", batch_size)
+        session = ort.InferenceSession(ai_path, sess_options=session_options, providers=providers)
+    else:
+        session = ort.InferenceSession(ai_path, providers=providers)
 
     logging.info(f"Available inference providers : {providers}")
     logging.info(f"Used inference providers : {session.get_providers()}")
@@ -113,9 +126,21 @@ def denoise(image, ai_path, strength, batch_size=4, window_size=256, stride=128,
             continue
 
         input_tiles = np.array(input_tiles)
+        num_input_tiles = len(input_tiles)
+
+        # The Core ML session has a fixed batch dimension. Duplicate the final
+        # tile to fill a partial batch; the padded results are discarded below.
+        if coreml_enabled and num_input_tiles < batch_size:
+            input_tiles = np.concatenate(
+                (
+                    input_tiles,
+                    np.repeat(input_tiles[-1:], batch_size - num_input_tiles, axis=0),
+                ),
+                axis=0,
+            )
 
         output_tiles = []
-        session_result = session.run(None, {"gen_input_image": input_tiles})[0]
+        session_result = session.run(None, {"gen_input_image": input_tiles})[0][:num_input_tiles]
         for e in session_result:
             output_tiles.append(e)
 

--- a/tests/test_ai_model_handling.py
+++ b/tests/test_ai_model_handling.py
@@ -1,0 +1,116 @@
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+# onnxruntime is installed separately per target platform and is intentionally
+# absent from requirements.txt. A fake module keeps these unit tests portable.
+fake_onnxruntime = SimpleNamespace(
+    get_available_providers=lambda: [],
+    InferenceSession=None,
+    SessionOptions=None,
+)
+sys.modules.setdefault("onnxruntime", fake_onnxruntime)
+
+from graxpert import ai_model_handling, denoising
+
+
+def test_coreml_provider_defaults_to_mlprogram(monkeypatch):
+    monkeypatch.setattr(
+        ai_model_handling.ort,
+        "get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    providers = ai_model_handling.get_execution_providers_ordered()
+
+    assert providers == [
+        (
+            "CoreMLExecutionProvider",
+            {
+                "ModelFormat": "MLProgram",
+                "MLComputeUnits": "ALL",
+                "RequireStaticInputShapes": "0",
+            },
+        ),
+        "CPUExecutionProvider",
+    ]
+
+
+def test_coreml_provider_supports_configurable_neuralnetwork_format(monkeypatch):
+    monkeypatch.setattr(
+        ai_model_handling.ort,
+        "get_available_providers",
+        lambda: ["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    providers = ai_model_handling.get_execution_providers_ordered(
+        coreml_model_format=ai_model_handling.COREML_MODEL_FORMAT_NEURALNETWORK,
+    )
+
+    assert providers[0] == (
+        "CoreMLExecutionProvider",
+        {
+            "ModelFormat": "NeuralNetwork",
+            "MLComputeUnits": "ALL",
+            "RequireStaticInputShapes": "0",
+        },
+    )
+
+
+def test_invalid_coreml_model_format_is_rejected():
+    with pytest.raises(ValueError, match="Unsupported Core ML model format"):
+        ai_model_handling.get_execution_providers_ordered(coreml_model_format="invalid")
+
+
+def test_denoising_fixes_and_pads_coreml_batch_dimension(monkeypatch):
+    captured = {}
+
+    def fake_get_execution_providers(gpu_acceleration):
+        captured["gpu_acceleration"] = gpu_acceleration
+        return ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+    class FakeSessionOptions:
+        def __init__(self):
+            captured["dimension_overrides"] = []
+
+        def add_free_dimension_override_by_name(self, name, value):
+            captured["dimension_overrides"].append((name, value))
+
+    class FakeInferenceSession:
+        def __init__(self, model_path, sess_options, providers):
+            captured["model_path"] = model_path
+            captured["session_options"] = sess_options
+            captured["providers"] = providers
+            captured["input_shapes"] = []
+
+        def get_providers(self):
+            return captured["providers"]
+
+        def run(self, _output_names, inputs):
+            captured["input_shapes"].append(inputs["gen_input_image"].shape)
+            return [inputs["gen_input_image"]]
+
+    monkeypatch.setattr(denoising, "get_execution_providers_ordered", fake_get_execution_providers)
+    monkeypatch.setattr(denoising.ort, "SessionOptions", FakeSessionOptions)
+    monkeypatch.setattr(denoising.ort, "InferenceSession", FakeInferenceSession)
+    monkeypatch.setattr(denoising, "cached_denoised_image", None)
+
+    image = np.random.default_rng(42).random((8, 8, 3), dtype=np.float32)
+    result = denoising.denoise(
+        image,
+        "model.onnx",
+        strength=1.0,
+        batch_size=4,
+        window_size=4,
+        stride=2,
+    )
+
+    assert result.shape == image.shape
+    assert captured["gpu_acceleration"] is True
+    assert captured["dimension_overrides"] == [("batch_size", 4)]
+    assert captured["model_path"] == "model.onnx"
+    assert captured["providers"] == ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+    assert all(shape == (4, 4, 4, 3) for shape in captured["input_shapes"])


### PR DESCRIPTION
## Summary

- configure the ONNX Runtime Core ML execution provider with the current provider options and all available Apple compute units
- specialize the denoising model's symbolic batch dimension so Core ML can compile and execute the MLProgram on Apple Silicon
- pad the final partial tile batch to the specialized size and discard the padding outputs
- add portable regression tests for Core ML provider configuration, validation, batch specialization, and padding

## Root cause and impact

The denoising ONNX model exposes a dynamic `batch_size` dimension. Core ML cannot build a usable MLProgram execution plan for that unbounded shape, so denoising either fails to initialize the accelerated provider or runs on the CPU fallback. Specializing the dimension to the configured batch size makes the graph eligible for Core ML hardware acceleration while preserving support for partial final batches.

On an Apple Silicon Mac with ONNX Runtime 1.28.0 and denoising model 3.0.2, the fixed-shape session assigned 1,599 of 1,636 graph nodes to Core ML. Warm batch inference measured about 0.17 seconds versus 1.76 seconds on CPU. An end-to-end comparison produced a mean absolute difference of 0.000137 and a maximum absolute difference of 0.00111 from the CPU result.

## Validation

- `python -m pytest --import-mode=append -q tests/` — 44 passed
- `python -m compileall -q graxpert tests/test_ai_model_handling.py`
- `git diff --check`
- real Core ML end-to-end inference with local denoising model 3.0.2 on Apple Silicon
